### PR TITLE
fixed some problems with resolution of genes for organisms and gene families

### DIFF
--- a/server/apollo-server/schema.graphql
+++ b/server/apollo-server/schema.graphql
@@ -26,7 +26,7 @@ type GeneFamily {
 type Query {
   organisms(genus: String, start: Int, size: Int): [Organism]
   organism(id: ID!): Organism
-  genes(family: ID, start: Int, size: Int): [Gene]
+  genes(organism: ID, family: ID, start: Int, size: Int): [Gene]
   gene(id: ID!): Gene
   geneFamilies(start: Int, size: Int): [GeneFamily]
   geneFamily(id: ID!): GeneFamily

--- a/server/apollo-server/src/resolvers.js
+++ b/server/apollo-server/src/resolvers.js
@@ -12,8 +12,8 @@ const resolvers = {
     },
 
     // gene API
-    genes: async (_source, { family, start, size }, { dataSources }) => {
-      return dataSources.legumemineAPI.getGenes({family, start, size});
+    genes: async (_source, { organism, family, start, size }, { dataSources }) => {
+      return dataSources.legumemineAPI.getGenes({organism, family, start, size});
     },
     gene: async (_source, { id }, { dataSources }) => {
       return dataSources.legumemineAPI.getGene(id);
@@ -30,9 +30,9 @@ const resolvers = {
 
   // organism attribute resolvers
   Organism: {
-    genes: async (gene, { }, { dataSources }) => {
-      const organism = gene.organismId;
-      return dataSources.legumemineAPI.getGenes({organism});
+    genes: async (organism, { }, { dataSources }) => {
+      const organism_id = organism.id;
+      return dataSources.legumemineAPI.getGenes({organism: organism_id});
     },
   },
 
@@ -49,8 +49,8 @@ const resolvers = {
   // gene family attribute resolvers
   GeneFamily: {
     genes: async (geneFamily, { }, { dataSources }) => {
-      const family = geneFamily.id;
-      return dataSources.legumemineAPI.getGenes({family});
+      const family_id = geneFamily.id;
+      return dataSources.legumemineAPI.getGenes({family:family_id});
     },
   },
 };


### PR DESCRIPTION
also added organism as a parameter to genes query, but that probably wasn't actually necessary to what I was really intending to fix (and I also suspect we ought not to expose intermine internal ids in our API, but we can figure that out later)
@alancleary thanks for setting me straight on the named parameters business, which was a new javascript syntactical oddity on me, although I think part of my confusion may have come from the way that the functions in question were being invoked previously (ie without naming) Hopefully this version works better, but feel free to school me some more since I clearly need it badly when working with js.